### PR TITLE
Fix link-directory theme reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ url: "https://unimelblinks.github.io" # the base hostname & protocol for your si
 exclude: ['README.md', 'CONTRIBUTING.md', 'Gemfile.lock', 'Gemfile']
 
 # link-directory theme config
-remote_theme: evilgoldfish/link-directory
+remote_theme: epetousis/link-directory
 real_name: University of Melbourne
 real_home: "https://unimelb.edu.au"
 source_url: "https://github.com/unimelblinks/unimelblinks.github.io"


### PR DESCRIPTION
Hi,

I recently updated my username and noticed this site is still referencing my old one. You should update the theme reference to make sure the theme is still able to be pulled and updated.